### PR TITLE
[t118814] Fix: Parameter ctx was not guaranteed to be iterable.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -387,6 +387,7 @@ class exporter(object):
 
         The optional context (ctx) is to test easily.
         """
+        ctx = ctx if ctx else {}
         self.map_locations = {}
         self.warehouses = set()
 


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=118814">[t118814] [MIGT] [DEV] [mt10721] [mt1874] Migration Frepple Connector V13</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->