### PR TITLE
[t118814] Fix: <operationplan> exported unknown attribute 'locked', and 'start' and 'end' were not compliant.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1121,10 +1121,10 @@ class exporter(object):
                 qty = self.convert_qty_uom(
                     i["product_qty"], i["product_uom_id"][0], i["product_id"][0]
                 )
-                yield '<operationplan reference=%s start="%s" end="%s" quantity="%s" locked="true"><operation name=%s/></operationplan>\n' % (
+                yield '<operationplan reference=%s start="%s" end="%s" quantity="%s"><operation name=%s/></operationplan>\n' % (
                     quoteattr(i["name"]),
-                    startdate,
-                    startdate,
+                    startdate.replace(' ', 'T'),
+                    startdate.replace(' ', 'T'),
                     qty,
                     quoteattr(operation),
                 )


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=118814">[t118814] [MIGT] [DEV] [mt10721] [mt1874] Migration Frepple Connector V13</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->