### PR TITLE
[t118814] Fix on <operationplan>: bad call to replace() over a datetime.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1123,8 +1123,8 @@ class exporter(object):
                 )
                 yield '<operationplan reference=%s start="%s" end="%s" quantity="%s"><operation name=%s/></operationplan>\n' % (
                     quoteattr(i["name"]),
-                    startdate.replace(' ', 'T'),
-                    startdate.replace(' ', 'T'),
+                    startdate.strftime('%Y-%m-%dT%H:%M:%S'),
+                    startdate.strftime('%Y-%m-%dT%H:%M:%S'),
                     qty,
                     quoteattr(operation),
                 )


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=118814">[t118814] [MIGT] [DEV] [mt10721] [mt1874] Migration Frepple Connector V13</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->