### PR TITLE
[t119072] Implements the import of a Distribution Order in frePPLe

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1358,6 +1358,10 @@ class exporter(object):
             location_origin = move_line.location_id
             location_dest = move_line.location_dest_id
 
+            # We do this to ensure a matching between the outgoing and the incoming software.
+            if not move_line.frepple_reference:
+                move_line.frepple_reference = move_line.id
+
             xml_str.append(
                 '<operationplan '
                 'ordertype="DO" '
@@ -1365,7 +1369,7 @@ class exporter(object):
                 'start="{start}" '
                 'quantity="{quantity}" '
                 'status="{status}">'.format(
-                    reference=move_line.id,
+                    reference=move_line.frepple_reference,
                     start=move_line.date.strftime("%Y-%m-%dT%H:%M:%S"),
                     quantity=move_line.qty_done,
                     status=status_mapping.get(move_line.state, 'closed')))

--- a/frepple/models/__init__.py
+++ b/frepple/models/__init__.py
@@ -3,3 +3,4 @@ from . import res_config_settings
 from . import res_partner
 from . import sale_order_line
 from . import product_product
+from . import stock_move_line

--- a/frepple/models/stock_move_line.py
+++ b/frepple/models/stock_move_line.py
@@ -1,0 +1,153 @@
+##############################################################################
+# Copyright (c) 2020 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+import os
+import logging
+from odoo import models, api, fields
+
+_logger = logging.getLogger(__name__)
+
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    frepple_reference = fields.Char('Reference (frePPLe)')
+
+    @api.model
+    def _create_or_update_from_frepple_operation_plan(self, elem):
+        """ Receives an XML subtree from an input file from frePPLe,
+            in particular an <operationplan>, and creates a stock.move
+            for it; or updates it if it already exists.
+
+            I'm assuming here that the inbound follows the same content
+            than the outbound I'm sending, which includes, among other things,
+            the ID of the products so that we don't have to search them by
+            name. Would be good that we exported the reference of the product
+            instead.
+        """
+        product_product = self.env['product.product']
+        stock_location = self.env['stock.location']
+        stock_move = self.env['stock.move']
+
+        elem_reference = elem.get('reference')
+        elem_date = (elem.get('start') or elem.get('end', '')).replace('T', ' ')
+
+        from_location = self.env['stock.location']
+        to_location = self.env['stock.location']
+        product = self.env['product.product']  # To silent the IDE.
+
+        # If we find at least one error, we inform and skip the element update/creation.
+        errors = []
+
+        for sub_elem in elem:
+
+            if sub_elem.tag == 'item':
+                # If we receive the ID of the product inside the parameter category_id, we use it.
+                # If we don't receive it, then we have to search the product using its name only.
+                product_search_domain = [('name', '=', sub_elem.get('name'))]
+                subcategory_attr = sub_elem.get('subcategory')
+                if subcategory_attr and ',' in subcategory_attr and subcategory_attr.split(',')[-1].isdigit():
+                    product_id = int(subcategory_attr.split(',')[-1])
+                    product_search_domain.append(('id', '=', product_id))
+                product = product_product.search(product_search_domain)
+                if not product:
+                    errors.append('No product was found for {}'.format(product_search_domain))
+                elif len(product) > 1:
+                    errors.append('More than one product was found for {}'.format(product_search_domain))
+
+            elif sub_elem.tag in {'origin', 'location'}:
+                # If we receive the ID of the location as the parameter subcategory, we use it.
+                # If we don't receive it, then we have to search the location using its name only.
+                location_search_domain = [('name', '=', sub_elem.get('name'))]
+                subcategory_attr = sub_elem.get('subcategory')
+                if subcategory_attr and subcategory_attr.isdigit():
+                    location_id = int(subcategory_attr)
+                    location_search_domain.append(('id', '=', location_id))
+                location = stock_location.search(location_search_domain)
+                if not location:
+                    errors.append('No location was found for {}'.format(location_search_domain))
+                elif len(location) > 1:
+                    errors.append('More than one location was found for {}'.format(location_search_domain))
+                else:
+                    if sub_elem.tag == 'origin':
+                        from_location = location
+                    else:  # if sub_elem.tag == 'location'
+                        to_location = location
+
+        if not from_location:
+            errors.append('No origin location found.')
+        if not to_location:
+            errors.append('No destination location found.')
+
+        if errors:
+            _logger.error('The following errors were found when processing <operationplan> with '
+                          'ordertype "DO" for reference {}: {}'.format(elem_reference, os.linesep.join(errors)))
+        else:
+            # TODO: Code to deal with states different than proposed and approved is pending.
+            #       The other statuses don't allow an edit in the UI, probably neither in the
+            #       backend ─ this has to be checked to know what we can update safely and
+            #       what we can't update (or can update, but being super-careful).
+            status_mapping = {
+                'proposed': 'draft',
+                'approved': 'waiting',
+                # 'approved': 'confirmed',
+                # 'approved': 'partially_available',
+                'confirmed': 'assigned',
+                'completed': 'done',
+                'closed': 'cancel',
+            }
+            move_line_values = {
+                'frepple_reference': elem_reference,
+                'state': status_mapping.get(elem.get('status'), 'draft'),
+                'location_dest_id': to_location.id,
+                'location_id': from_location.id,
+                'product_id': product.id,
+                'product_uom_id': product.uom_id.id,
+                'product_uom_qty': elem.get('quantity'),
+                # 'move_id': ?.id  # To add it later.
+            }
+            move_values = {
+                'name': 'frePPLe - {} - {}'.format(elem_reference, product.name),
+                'location_id': from_location.id,
+                'location_dest_id': to_location.id,
+                'product_id': product.id,
+                'product_uom': product.uom_id.id,
+                'product_uom_qty': elem.get('quantity'),
+                'state': status_mapping.get(elem.get('status'), 'draft'),
+                'date': elem_date,
+                'date_expected': elem_date,
+            }
+            move_line = self.search([
+                ('frepple_reference', '=', elem_reference),
+                ('state', 'not in', ['done', 'cancel']),
+            ])
+            if move_line:
+                move_line.write(move_line_values)
+                move = move_line.move_id
+                move.write(move_values)
+            else:
+                move = stock_move.create(move_values)
+                move_line_values['move_id'] = move.id
+                move_line = self.create(move_line_values)
+
+            # We group the move into a picking. If doesn't already exists, we create it.
+            if not move.picking_id:
+                picking = self.env['stock.picking'].search([
+                    ('state', 'in', ['draft', 'waiting']),
+                    ('scheduled_date', '=', elem_date),
+                    ('location_id', '=', from_location.id),
+                    ('location_dest_id', '=', to_location.id),
+                ], limit=1)
+                if not picking:
+                    picking = self.env['stock.picking'].create({
+                        'picking_type_id': self.env.ref('stock.picking_type_internal').id,
+                        'scheduled_date': elem_date,
+                        'location_id': from_location.id,
+                        'location_dest_id': to_location.id,
+                    })
+                move.picking_id = picking
+                move_line.picking_id = picking

--- a/frepple/tests/__init__.py
+++ b/frepple/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_outbound_locations
 from . import test_outbound_move_lines
 from . import test_outbound_stock_rules
 from . import test_outbound_saleorders
+from . import test_inbound_ordertype_do

--- a/frepple/tests/test_inbound_ordertype_do.py
+++ b/frepple/tests/test_inbound_ordertype_do.py
@@ -1,0 +1,223 @@
+##############################################################################
+# Copyright (c) 2020 brain-tec AG (https://braintec-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from tempfile import mkstemp
+import os
+from unittest import skipIf
+from odoo.addons.frepple.tests.test_base import TestBase
+from odoo import fields
+
+UNDER_DEVELOPMENT = False
+UNDER_DEVELOPMENT_MSG = 'Test skipped because of being under development'
+
+
+class TestInboundOrdertypeDo(TestBase):
+    def setUp(self):
+        super(TestInboundOrdertypeDo, self).setUp()
+        self.product = self._create_product('Product #1', price=1)
+        self.dest_loc = self._create_location('Destination Location')
+        self.source_loc = self._create_location('Source Location')
+
+    def _create_xml(self, reference, product, source_location, destination_location, qty, datetime_xml=None):
+        if datetime_xml is None:
+            datetime_xml = fields.Datetime.to_string(fields.Datetime.now()).replace(' ', 'T')
+        xml_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+            <plan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" source="odoo_1">
+                <operationplans>
+                    <operationplan reference="{reference}" ordertype="DO"
+                      start="{datetime}" end="{datetime}"
+                      quantity="{qty:0.6f}" status="proposed">
+                        <item name="{product_name}" subcategory=",{product_id}" description="Product"/>
+                        <location name="{location_name}" subcategory="{location_id}" description="Dest. location"/>
+                        <origin name="{origin_name}" subcategory="{origin_id}" description="Origin location"/>
+                    </operationplan>
+                </operationplans>
+            </plan>
+        '''.format(reference=reference,
+                   product_name=product.name,
+                   product_id=product.id,
+                   location_name=destination_location.name,
+                   location_id=destination_location.id,
+                   origin_name=source_location.name,
+                   origin_id=source_location.id,
+                   qty=qty,
+                   datetime=datetime_xml)
+        fd, xml_file_path = mkstemp(prefix='frepple_inbound_xml_', dir="/tmp")
+        f = open(xml_file_path, 'w')
+        f.write(xml_content)
+        f.close()
+        os.close(fd)
+        return xml_content, xml_file_path
+
+    def _assert_expected(self, picking, move_line, expected_qty):
+        """ We are always asserting the same. So the assertions are extracted here.
+        """
+        self.assertEqual(len(picking.move_line_ids), 1)
+        self.assertEqual(len(picking.move_lines), 1)
+        self.assertEqual(move_line.product_id, self.product)
+        self.assertEqual(move_line.move_id.product_id, self.product)
+        self.assertEqual(move_line.product_uom_qty, expected_qty)
+        self.assertEqual(move_line.move_id.product_uom_qty, expected_qty)
+        self.assertEqual(len(picking), 1)
+        self.assertEqual(picking.location_dest_id, self.dest_loc)
+        self.assertEqual(picking.location_id, self.source_loc)
+        self.assertEqual(move_line.picking_id, picking)
+        self.assertEqual(move_line.move_id.picking_id, picking)
+
+    @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
+    def test_ordertype_do_all_new(self):
+        """ Tests an input XML that creates a new move and a new picking.
+        """
+        stock_picking = self.env['stock.picking']
+        stock_move_line = self.env['stock.move.line']
+
+        ref = 'ref-001'
+        qty = 100
+
+        self.assertFalse(stock_move_line.search([
+            ('frepple_reference', '=', ref),
+        ]))
+        self.assertFalse(stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ]))
+
+        _, xml_file = self._create_xml(
+            ref, self.product, self.source_loc, self.dest_loc, qty=qty)
+        f = open(xml_file, 'r')
+        self.importer.datafile = f
+        self.importer.run()
+        f.close()
+
+        move_line = stock_move_line.search([('frepple_reference', '=', ref)])
+        picking = stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ])
+        self.assertEqual(len(move_line), 1)
+        self._assert_expected(picking, move_line, qty)
+
+    @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
+    def test_ordertype_do_moveline_new_picking_exists(self):
+        """ Tests an input XML that creates a new move and adds it to a picking that already exists.
+        """
+        stock_picking = self.env['stock.picking']
+        stock_move_line = self.env['stock.move.line']
+
+        datetime_str_odoo = fields.Datetime.to_string(fields.Datetime.now())
+        datetime_str_xml = datetime_str_odoo.replace(' ', 'T')
+
+        # A picking already exists.
+        picking = self._create_internal_picking(
+            self.source_loc, self.dest_loc, defaults={'scheduled_date': datetime_str_odoo})
+        self.assertFalse(picking.move_lines)
+        self.assertFalse(picking.move_line_ids)
+
+        ref = 'ref-002'
+        qty = 200
+        _, xml_file = self._create_xml(
+            ref, self.product, self.source_loc, self.dest_loc, qty=qty, datetime_xml=datetime_str_xml)
+        f = open(xml_file, 'r')
+        self.importer.datafile = f
+        self.importer.run()
+        f.close()
+
+        move_line = stock_move_line.search([('frepple_reference', '=', ref)])
+        self.assertEqual(stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ]), picking)
+        self.assertEqual(len(move_line), 1)
+        self._assert_expected(picking, move_line, qty)
+
+    @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
+    def test_ordertype_do_moveline_exists_picking_new(self):
+        """ Tests an input XML that updates an already existing move, that is not yet for a picking
+        """
+        stock_picking = self.env['stock.picking']
+        stock_move_line = self.env['stock.move.line']
+
+        ref = 'ref-003'
+        qty = 300
+
+        # The move line already exists.
+        move_line = self._create_move_line(
+            self.source_loc, self.dest_loc, self.product,
+            defaults_move={'product_uom_qty': qty},
+            defaults_move_line={'frepple_reference': ref})
+
+        self.assertEqual(stock_move_line.search([
+            ('frepple_reference', '=', ref),
+        ]), move_line)
+        self.assertFalse(stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ]))
+
+        _, xml_file = self._create_xml(
+            ref, self.product, self.source_loc, self.dest_loc, qty=qty + 3)
+        f = open(xml_file, 'r')
+        self.importer.datafile = f
+        self.importer.run()
+        f.close()
+
+        move_line_after = stock_move_line.search([('frepple_reference', '=', ref)])
+        self.assertEqual(move_line, move_line_after)
+        picking = stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ])
+        self.assertEqual(len(move_line), 1)
+        self._assert_expected(picking, move_line, qty + 3)
+
+    @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
+    def test_ordertype_do_moveline_exists_picking_exists(self):
+        """ Tests an input XML that updates a move that is already linked to a picking that exists.
+        """
+        stock_picking = self.env['stock.picking']
+        stock_move_line = self.env['stock.move.line']
+
+        datetime_str_odoo = fields.Datetime.to_string(fields.Datetime.now())
+
+        ref = 'ref-003'
+        qty = 300
+
+        # The move line already exists.
+        move_line = self._create_move_line(
+            self.source_loc, self.dest_loc, self.product,
+            defaults_move={'product_uom_qty': qty},
+            defaults_move_line={'frepple_reference': ref})
+
+        # A picking already exists.
+        picking = self._create_internal_picking(
+            self.source_loc, self.dest_loc, defaults={'scheduled_date': datetime_str_odoo})
+        self.assertFalse(picking.move_lines)
+        self.assertFalse(picking.move_line_ids)
+
+        self.assertEqual(stock_move_line.search([
+            ('frepple_reference', '=', ref),
+        ]), move_line)
+        self.assertEqual(stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ]), picking)
+
+        _, xml_file = self._create_xml(
+            ref, self.product, self.source_loc, self.dest_loc, qty=qty + 7)
+        f = open(xml_file, 'r')
+        self.importer.datafile = f
+        self.importer.run()
+        f.close()
+
+        move_line_after = stock_move_line.search([('frepple_reference', '=', ref)])
+        self.assertEqual(move_line, move_line_after)
+        picking_after = stock_picking.search([
+            ('location_id', '=', self.source_loc.id),
+            ('location_dest_id', '=', self.dest_loc.id),
+        ])
+        self.assertEqual(picking, picking_after)
+        self._assert_expected(picking, move_line, qty + 7)


### PR DESCRIPTION
- A distribution order is encoded in the XML as an \<ordertype\> with ordertype 'DO'.
- If a stock.move.line with the same reference exists and isn't done or cancelled then it is updated;
  otherwise it's created.
- The stock.move.line are grouped into pickings depending on its <source, destination, time>.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->