### PR TITLE
[t119072] <demand>s that represent a sale.order have a fixed priority of 10.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1021,7 +1021,7 @@ class exporter(object):
             due = getattr(sale_order, 'requested_date', False) or sale_order.date_order
 
             xml_str.extend([
-                '<demand name={} quantity="{}" due="{}" priority="1" '
+                '<demand name={} quantity="{}" due="{}" priority="10" '
                 'minshipment="{}" description="status={}">'.format(
                     quoteattr(name), qty, due.strftime('%Y-%m-%dT%H:%M:%S'),
                     sale_order.picking_policy == 'one' and qty or 1.0, frepple_status,

--- a/frepple/tests/test_outbound_saleorders.py
+++ b/frepple/tests/test_outbound_saleorders.py
@@ -37,7 +37,7 @@ class TestOutboundItems(TestBase):
         xml_str_expected = ''.join(map(re.escape, [
             '<!-- sales order lines -->',
             '<demands>',
-            '<demand name="{}" quantity="1.0" due="{}" priority="1" '
+            '<demand name="{}" quantity="1.0" due="{}" priority="10" '
             'minshipment="1.0" description="status=quote">'.format(
                 '{} {}'.format(quotation.name, quotation.order_line[0].id),
                 due.strftime('%Y-%m-%dT%H:%M:%S')),
@@ -68,7 +68,7 @@ class TestOutboundItems(TestBase):
         xml_str_expected = ''.join(map(re.escape, [
             '<!-- sales order lines -->',
             '<demands>',
-            '<demand name="{}" quantity="0.5" due="{}" priority="1" '
+            '<demand name="{}" quantity="0.5" due="{}" priority="10" '
             'minshipment="1.0" description="status=quote">'.format(
                 '{} {}'.format(quotation.name, quotation.order_line[0].id),
                 due.strftime('%Y-%m-%dT%H:%M:%S')),


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->