### PR TITLE
[t119072] Moves to a more Odoo-like development.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -421,24 +421,6 @@ class exporter(object):
         xml_str.append('</locations>')
         return '\n'.join(xml_str)
 
-    def _export_customers(self, customers):
-        """ Auxiliary method to export the customers.
-            If partner_affiliates is installed, the field affiliate_ids will be
-            inside the res.partner, so we use it.
-        """
-        xml_str = []
-        if customers:
-            for customer in customers:
-                customer_name = '{} {}'.format(customer.id, customer.name)
-                common_fields = self._frepple_generate_common_fields_xml(customer)
-                if common_fields:
-                    xml_str.append('<customer name={}>'.format(quoteattr(customer_name)))
-                    xml_str.extend(common_fields)
-                    xml_str.append('</customer>')
-                else:
-                    xml_str.append('<customer name={}/>'.format(quoteattr(customer_name)))
-        return xml_str
-
     def export_customers(self, ctx=None):
         """
         Generate a list of customers to frePPLe, based on the res.partner model.
@@ -453,21 +435,7 @@ class exporter(object):
         """
         if ctx is None:
             ctx = {}
-
-        customers = self.env['res.partner'].search([
-            ('customer_rank', '>', 0),
-            ('parent_id', '=', False),
-        ], order='id')
-        if 'test_export_customers' in ctx:
-            customers = customers.filtered(lambda customer: customer.name.startswith(ctx['test_prefix']))
-
-        xml_str = [
-            '<!-- customers -->',
-            '<customers>',
-        ]
-        xml_str.extend(self._export_customers(customers))
-        xml_str.append('</customers>')
-        return '\n'.join(xml_str)
+        return self.env['res.partner'].with_context(ctx)._frepple_export_customers_xml()
 
     def export_suppliers(self):
         """

--- a/frepple/models/res_partner.py
+++ b/frepple/models/res_partner.py
@@ -5,7 +5,8 @@
 # See LICENSE file for full licensing details.
 ##############################################################################
 
-from odoo import models
+from xml.sax.saxutils import quoteattr
+from odoo import models, api
 
 
 class ResPartner(models.Model):
@@ -22,3 +23,47 @@ class ResPartner(models.Model):
         """
         self.ensure_one()
         return []
+
+    def _frepple_generate_common_fields_xml(self):
+        self.ensure_one()
+        xml_str = []
+        for field_type, field_name, field_value in self._frepple_get_common_fields():
+            xml_str.append('<{} name="{}" value={}/>'.format(
+                field_type, field_name, quoteattr(field_value)))
+        return xml_str
+
+    def _frepple_export_customer_xml(self):
+        """ Exports as a frePPLe's <customer>
+        """
+        self.ensure_one()
+        xml_str = []
+        customer_name = '{} {}'.format(self.id, self.name)
+        common_fields = self._frepple_generate_common_fields_xml()
+        if common_fields:
+            xml_str.append('<customer name={}>'.format(quoteattr(customer_name)))
+            xml_str.extend(common_fields)
+            xml_str.append('</customer>')
+        else:
+            xml_str.append('<customer name={}/>'.format(quoteattr(customer_name)))
+        return xml_str
+
+    @api.model
+    def _frepple_export_customers_xml(self):
+        """ Export as a frePPLe's <customers>
+        """
+        customers = self.env['res.partner'].search([
+            ('customer_rank', '>', 0),
+            ('parent_id', '=', False),
+        ], order='id')
+        if 'test_prefix' in self.env.context:
+            customers = customers.filtered(
+                lambda customer: customer.name.startswith(self.env.context['test_prefix']))
+
+        xml_str = [
+            '<!-- customers -->',
+            '<customers>',
+        ]
+        for customer in customers:
+            xml_str.extend(customer._frepple_export_customer_xml())
+        xml_str.append('</customers>')
+        return '\n'.join(xml_str)

--- a/frepple/tests/test_outbound_customers.py
+++ b/frepple/tests/test_outbound_customers.py
@@ -21,7 +21,7 @@ class TestOutboundCustomers(TestBase):
         """ Generates XML for customer that has an & in its name
         """
         customer_1 = self._create_customer('TC_Brain & Tec')
-        xml_str_actual = self.exporter.export_customers(ctx={'test_export_customers': True, 'test_prefix': 'TC_'})
+        xml_str_actual = self.exporter.export_customers(ctx={'test_prefix': 'TC_'})
         xml_str_expected = '\n'.join([
             '<!-- customers -->',
             '<customers>',
@@ -36,7 +36,7 @@ class TestOutboundCustomers(TestBase):
         """
         customer_1 = self._create_customer('TC_1')
         customer_2 = self._create_customer('TC_2')
-        xml_str_actual = self.exporter.export_customers(ctx={'test_export_customers': True, 'test_prefix': 'TC_'})
+        xml_str_actual = self.exporter.export_customers(ctx={'test_prefix': 'TC_'})
         xml_str_expected = '\n'.join([
             '<!-- customers -->',
             '<customers>',


### PR DESCRIPTION
The amount of monkey-patches was exploding because of different modules that
could be installed independently, each of which had generated a monkey-patch
to extend certain variants for the XML.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->