### PR TITLE
[t119072] Splits the code of generating the customers into smaller pieces, to allow more place to hook.

### DIFF
--- a/frepple/models/res_partner.py
+++ b/frepple/models/res_partner.py
@@ -36,19 +36,19 @@ class ResPartner(models.Model):
         self.ensure_one()
         return '{} {}'.format(self.id, self.name)
 
-    def _frepple_export_customer_xml(self):
+    def _frepple_export_customer_tags_xml(self):
         """ Exports as a frePPLe's <customer>
         """
-        self.ensure_one()
         xml_str = []
-        customer_name = self._frepple_customer_name()
-        common_fields = self._frepple_generate_common_fields_xml()
-        if common_fields:
-            xml_str.append('<customer name={}>'.format(quoteattr(customer_name)))
-            xml_str.extend(common_fields)
-            xml_str.append('</customer>')
-        else:
-            xml_str.append('<customer name={}/>'.format(quoteattr(customer_name)))
+        for record in self:
+            customer_name = record._frepple_customer_name()
+            common_fields = record._frepple_generate_common_fields_xml()
+            if common_fields:
+                xml_str.append('<customer name={}>'.format(quoteattr(customer_name)))
+                xml_str.extend(common_fields)
+                xml_str.append('</customer>')
+            else:
+                xml_str.append('<customer name={}/>'.format(quoteattr(customer_name)))
         return xml_str
 
     @api.model
@@ -61,8 +61,7 @@ class ResPartner(models.Model):
         if 'test_prefix' in self.env.context:
             customers = customers.filtered(
                 lambda customer: customer.name.startswith(self.env.context['test_prefix']))
-        for customer in customers:
-            xml_str.extend(customer._frepple_export_customer_xml())
+        xml_str.extend(customers._frepple_export_customer_tags_xml())
         return xml_str
 
     @api.model


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->