### PR TITLE
[t119072] Status of a <demand> is exported with the attribute "status" and not "description".

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1022,7 +1022,7 @@ class exporter(object):
 
             xml_str.extend([
                 '<demand name={} quantity="{}" due="{}" priority="10" '
-                'minshipment="{}" description="status={}">'.format(
+                'minshipment="{}" status="{}">'.format(
                     quoteattr(name), qty, due.strftime('%Y-%m-%dT%H:%M:%S'),
                     sale_order.picking_policy == 'one' and qty or 1.0, frepple_status,
                 ),

--- a/frepple/tests/test_outbound_saleorders.py
+++ b/frepple/tests/test_outbound_saleorders.py
@@ -38,7 +38,7 @@ class TestOutboundItems(TestBase):
             '<!-- sales order lines -->',
             '<demands>',
             '<demand name="{}" quantity="1.0" due="{}" priority="10" '
-            'minshipment="1.0" description="status=quote">'.format(
+            'minshipment="1.0" status="quote">'.format(
                 '{} {}'.format(quotation.name, quotation.order_line[0].id),
                 due.strftime('%Y-%m-%dT%H:%M:%S')),
             '<item name="{}"/>'.format(self.product.name),
@@ -69,7 +69,7 @@ class TestOutboundItems(TestBase):
             '<!-- sales order lines -->',
             '<demands>',
             '<demand name="{}" quantity="0.5" due="{}" priority="10" '
-            'minshipment="1.0" description="status=quote">'.format(
+            'minshipment="1.0" status="quote">'.format(
                 '{} {}'.format(quotation.name, quotation.order_line[0].id),
                 due.strftime('%Y-%m-%dT%H:%M:%S')),
             '<item name="{}"/>'.format(self.product.name),


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->