### PR TITLE
[t119072] Changes the format of the input <operationplan>

### DIFF
--- a/frepple/__manifest__.py
+++ b/frepple/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "frepple",
-    "version": "13.0.6.7.1",
+    "version": "13.0.6.7.2",
     "category": "Manufacturing",
     "summary": "Advanced planning and scheduling",
     "author": "frePPLe, brain-tec AG",

--- a/frepple/tests/test_inbound_ordertype_do.py
+++ b/frepple/tests/test_inbound_ordertype_do.py
@@ -30,11 +30,12 @@ class TestInboundOrdertypeDo(TestBase):
                 <operationplans>
                     <operationplan reference="{reference}" ordertype="DO"
                       start="{datetime}" end="{datetime}"
-                      quantity="{qty:0.6f}" status="proposed">
-                        <item name="{product_name}" subcategory=",{product_id}" description="Product"/>
-                        <location name="{location_name}" subcategory="{location_id}" description="Dest. location"/>
-                        <origin name="{origin_name}" subcategory="{origin_id}" description="Origin location"/>
-                    </operationplan>
+                      quantity="{qty:0.6f}" status="proposed"
+                      item="{product_name}" item_id="{product_id}"
+                      origin="{origin_name}" origin_id="{origin_id}"
+                      destination="{location_name}" destination_id="{location_id}"
+                      criticality="1"
+                    />
                 </operationplans>
             </plan>
         '''.format(reference=reference,


### PR DESCRIPTION
The original implementation was done when we still didn't know the
format frePPLe used for the inbound <operationplan>, and made some
assumptions that were wrong, e.g. that the items and locations would
be similar to those of the outbound. Now those inner items have
been placed as attributes of the <operationplan>, following the
specifications given.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=119072">[t119072] [mt10726] Extend Frepple Connector - Parse DO in Incoming Frepple => Odoo and Replace Standard Hierarchy by Segmentation in Outgoing</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->