### PR TITLE
[bt#12719] Bugfixing states for mrp.production, and search based on b…

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -973,7 +973,9 @@ class exporter(object):
         yield "<!-- manufacturing orders in progress -->\n"
         yield "<operationplans>\n"
         m = self.env["mrp.production"]
-        recs = m.search([("state", "in", ["in_production", "ready", "confirmed"])])
+        sml = self.env["stock.move.line"]
+        # Adapting search to some existing states in v13
+        recs = m.search([("state", "in", ["confirmed", "planned", "progress", "to_close"])])
         fields = [
             "bom_id",
             "date_start",
@@ -984,20 +986,31 @@ class exporter(object):
             "product_uom_id",
             "location_dest_id",
             "product_id",
+            "finished_move_line_ids",
         ]
         for i in recs.read(fields):
-            if i["state"] in ("in_production", "confirmed", "ready") and i["bom_id"]:
+            if i["state"] and i["bom_id"]:
                 # Open orders
                 location = self.map_locations.get(i["location_dest_id"][0], None)
                 operation = u"%d %s @ %s" % (i["bom_id"][0], i["bom_id"][1], location)
                 startdate = i["date_start"] or i["date_planned_start"] or None
                 if not startdate:
                     continue
-                if not location or operation not in self.operations:
+                # Working with ids for bom_ids instead of with text, as it might lead to problems
+                # due to changes in name_get for instance
+                if not location or i["bom_id"][0] not in [int(x.split(' ')[0]) for x in self.operations]:
                     continue
                 qty = self.convert_qty_uom(
                     i["product_qty"], i["product_uom_id"][0], i["product_id"][0]
                 )
+                # qty would be here the qty to be produced. In case we already produced a part,
+                # we should rather decrease it with the qty already produced
+                if i["finished_move_line_ids"]:
+                    move_lines = sml.browse(i["finished_move_line_ids"])
+                    qty_done = 0
+                    for ml in move_lines:
+                        qty_done += self.convert_qty_uom(ml.qty_done, ml.product_uom_id.id, ml.product_id.id)
+                    qty -= qty_done
                 yield '<operationplan reference=%s start="%s" end="%s" quantity="%s" status="confirmed"><operation name=%s/></operationplan>\n' % (
                     quoteattr(i["name"]),
                     odoo_fields.Datetime.context_timestamp(m, startdate).strftime("%Y-%m-%dT%H:%M:%S"),


### PR DESCRIPTION
…om_id.

Changing returned qty to take into account the produced items, so that the returned qty really means qty pending to be produced

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12719">[bt#12719] [mt#1044] Frepple: Not All Manufacturing Orders Are Exported (+ Small CR)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->