### PR TITLE
[bt#12719] Bugifx when creating a MO from inbound xml, as it wasn't c…

### DIFF
--- a/frepple/__manifest__.py
+++ b/frepple/__manifest__.py
@@ -29,6 +29,7 @@
         "views/mrp_workcenter_inherit.xml",
         "views/mrp_workcenter_skill.xml",
         "views/mrp_routing_workcenter_inherit.xml",
+        "views/mrp_production.xml",
     ],
     "demo": ["data/demo.xml"],
     "test": [],

--- a/frepple/controllers/inbound.py
+++ b/frepple/controllers/inbound.py
@@ -138,23 +138,7 @@ class importer(object):
 
                     # elif ????:
                     else:
-                        uom_id, item_id = elem.get("item_id").split(",")
-                        # Create manufacturing order
-                        mfg_order.create(
-                            {
-                                "product_qty": elem.get("quantity"),
-                                "date_planned_start": elem.get("start"),
-                                "date_planned_finished": elem.get("end"),
-                                "product_id": int(item_id),
-                                "company_id": self.company.id,
-                                "product_uom_id": int(uom_id),
-                                "location_src_id": int(elem.get("location_id")),
-                                "bom_id": int(elem.get("operation").split(" ", 1)[0]),
-                                # TODO no place to store the criticality
-                                # elem.get('criticality'),
-                                "origin": "frePPLe",
-                            }
-                        )
+                        self._create_or_update_mo(elem, self.company)
                         countmfg += 1
                 except Exception as e:
                     logger.error("Exception %s" % e)
@@ -172,3 +156,6 @@ class importer(object):
 
     def _create_or_update_stock_move_line(self, elem):
         self.env['stock.move.line']._create_or_update_from_frepple_operation_plan(elem)
+
+    def _create_or_update_mo(self, elem, company):
+        self.env['mrp.production']._create_or_update_from_frepple_mo(elem, company)

--- a/frepple/models/__init__.py
+++ b/frepple/models/__init__.py
@@ -9,3 +9,4 @@ from . import mrp_skill
 from . import mrp_workcenter_inherit
 from . import mrp_routing_workcenter_inherit
 from . import mrp_workcenter_skill
+from . import mrp_production

--- a/frepple/models/mrp_production.py
+++ b/frepple/models/mrp_production.py
@@ -1,0 +1,130 @@
+##############################################################################
+# Copyright (c) 2020 brain-tec AG (https://bt-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+import os
+import logging
+from odoo import models, api, fields
+from odoo.tests import Form
+
+_logger = logging.getLogger(__name__)
+
+
+class ManufacturingOrder(models.Model):
+    _inherit = 'mrp.production'
+
+    frepple_reference = fields.Char('Reference (frePPLe)')
+
+    @api.model
+    def _create_or_update_from_frepple_mo(self, elem, company):
+        """ Receives an XML subtree from an input file from frePPLe,
+            in particular an <operationplan>, and creates a mrp.production
+            for it; or updates it if it already exists.
+
+            I'm assuming here that the inbound follows the same content
+            than the outbound I'm sending, which includes, among other things,
+            the ID of the products so that we don't have to search them by
+            name. Would be good that we exported the reference of the product
+            instead.
+        """
+        product_product = self.env['product.product']
+        uom_uom = self.env['uom.uom']
+        stock_location = self.env['stock.location']
+        mrp_bom = self.env['mrp.bom']
+
+        elem_reference = elem.get('id')
+
+        # If we find at least one error, we inform and skip the element update/creation.
+        errors = []
+
+        uom_id, item_id = elem.get("item_id").split(",")
+
+        # Determines the product.
+        product_search_domain = [
+            ('id', '=', int(item_id)),
+            ('name', '=', elem.get('item', '')),
+        ]
+        product = product_product.search(product_search_domain)
+        if not product:
+            errors.append('No product was found for {}'.format(product_search_domain))
+        elif len(product) > 1:
+            errors.append('More than one product was found for {}'.format(product_search_domain))
+
+        # Determines the uom.
+        uom_search_domain = [
+            ('id', '=', int(uom_id)),
+        ]
+        uom = uom_uom.search(uom_search_domain)
+        if not uom:
+            errors.append('No uom was found for {}'.format(uom_search_domain))
+        elif len(uom) > 1:
+            errors.append('More than one uom was found for {}'.format(uom_search_domain))
+
+        # # Determines the origin location.
+        # location_search_domain = [
+        #     ('id', '=', elem.get('origin_id', 0)),
+        #     ('name', '=', elem.get('origin', '')),
+        # ]
+        # from_location = stock_location.search(location_search_domain)
+        # if not from_location:
+        #     errors.append('No location was found for {}'.format(location_search_domain))
+        # elif len(from_location) > 1:
+        #     errors.append('More than one location was found for {}'.format(location_search_domain))
+
+        # Determines the destination location.
+        location_search_domain = [
+            ('id', '=', int(elem.get('location_id', 0))),
+            ('name', '=', elem.get('location', '')),
+        ]
+        to_location = stock_location.search(location_search_domain)
+        if not to_location:
+            errors.append('No location was found for {}'.format(location_search_domain))
+        elif len(to_location) > 1:
+            errors.append('More than one location was found for {}'.format(location_search_domain))
+
+        # if not from_location:
+        #     errors.append('No origin location found.')
+        if not to_location:
+            errors.append('No destination location found.')
+
+        # Determines the bom.
+        bom_search_domain = [
+            ('id', '=', int(elem.get("operation").split(" ", 1)[0])),
+        ]
+        bom = mrp_bom.search(bom_search_domain)
+        if not bom:
+            errors.append('No bom was found for {}'.format(bom_search_domain))
+        elif len(bom) > 1:
+            errors.append('More than one bom was found for {}'.format(bom_search_domain))
+
+        if errors:
+            _logger.error('The following errors were found when processing <operationplan> with '
+                          'ordertype "MO" for reference {}: {}'.format(elem_reference, os.linesep.join(errors)))
+        else:
+            # TODO no place to store the criticality
+            # # elem.get('criticality'),
+            mo_values = {
+                'frepple_reference': elem_reference,
+                'product_qty': elem.get('quantity'),
+                'date_planned_start': elem.get("start").replace('T', ' '),
+                'date_planned_finished': elem.get("end").replace('T', ' '),
+                'product_id': product,
+                'company_id': company,
+                'product_uom_id': uom,
+                'location_src_id': to_location,
+                'bom_id': bom,
+                'origin': "frePPLe"
+            }
+
+            mo = self.search([('frepple_reference', '=', elem_reference)])
+
+            if mo:
+                f = Form(mo)
+            else:
+                f = Form(self)
+            for key, value in mo_values.items():
+                setattr(f, key, value)
+            f.save()

--- a/frepple/tests/test_base.py
+++ b/frepple/tests/test_base.py
@@ -96,6 +96,21 @@ class TestBase(TransactionCase):
             create_values['categ_id'] = category.id
         return self.env['product.product'].create(create_values)
 
+    def _create_bom(self, product, child_products):
+        bom_line_ids = []
+        for child_product in child_products:
+            bom_line_ids.append((0, 0,
+                                 {'product_id': child_product.id,
+                                  'product_qty': 1,
+                                  'product_uom_id': child_product.uom_id.id
+                                  }))
+        return self.env['mrp.bom'].create({
+            'product_tmpl_id': product.product_tmpl_id.id,
+            'product_qty': 1,
+            'product_uom_id': product.uom_id.id,
+            'bom_line_ids': bom_line_ids
+        })
+
     def _create_supplier_seller(self, name, product, priority, price, delay):
         supplier = self.env['res.partner'].create({
             'name': name,

--- a/frepple/tests/test_inbound_ordertype_mo.py
+++ b/frepple/tests/test_inbound_ordertype_mo.py
@@ -1,0 +1,106 @@
+##############################################################################
+# Copyright (c) 2020 brain-tec AG (https://braintec-group.com)
+# All Right Reserved
+#
+# See LICENSE file for full licensing details.
+##############################################################################
+
+from tempfile import mkstemp
+import os
+from unittest import skipIf
+from odoo.addons.frepple.tests.test_base import TestBase
+from odoo import fields
+
+UNDER_DEVELOPMENT = False
+UNDER_DEVELOPMENT_MSG = 'Test skipped because of being under development'
+
+
+class TestInboundOrdertypeDo(TestBase):
+    def setUp(self):
+        super(TestInboundOrdertypeDo, self).setUp()
+        self.product = self._create_product('Main Product', price=2)
+        self.sub_product_1 = self._create_product('Sub Product 1', price=1)
+        self.sub_product_2 = self._create_product('Sub Product 2', price=1)
+        self.bom = self._create_bom(self.product, [self.sub_product_1, self.sub_product_2])
+        self.dest_loc = self._create_location('ASM/Stock')
+        self.source_loc = self._create_location('Source Location')
+
+    def _create_xml(self, reference, product, bom, source_location, destination_location, qty, datetime_xml=None):
+        if datetime_xml is None:
+            datetime_xml = fields.Datetime.to_string(fields.Datetime.now())
+        """
+            Example
+            <operationplan 
+             ordertype="MO" 
+             id="186182386060"
+             item="CAFE ROYAL DG R Box x96 x16 x6" 
+             location="ASM/Stock"
+             location_id="8" 
+             operation="957 CAFE ROYAL DG R Box x96 x16 x6 @ ASM/Stock" 
+             start="2021-02-07 00:00:00" 
+             end="2021-02-08 00:00:00" 
+             quantity="60.00000000"
+             item_id="1,3563" 
+             criticality="0"/>             
+            """
+
+        xml_content = '''<?xml version="1.0" encoding="UTF-8" ?>
+            <plan xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" source="odoo_1">
+                <operationplans>
+                    <operationplan  
+                      ordertype="MO"
+                      id="{id}"
+                      item="{product_name}" 
+                      item_id="{uom_id},{product_id}"
+                      start="{datetime}" 
+                      end="{datetime}"
+                      quantity="{qty:0.6f}"
+                      origin="{origin_name}" 
+                      origin_id="{origin_id}"
+                      location="{location_name}" 
+                      location_id="{location_id}"
+                      operation="{operation}"
+                      criticality="0"
+                    />
+                </operationplans>
+            </plan>
+        '''.format(id=reference,
+                   product_name=product.name,
+                   product_id=product.id,
+                   location_name=destination_location.name,
+                   location_id=destination_location.id,
+                   origin_name=source_location.name,
+                   origin_id=source_location.id,
+                   qty=qty,
+                   datetime=datetime_xml,
+                   operation="{0} {1} @ {2}".format(bom.id, product.name, destination_location.name),
+                   uom_id=product.uom_id.id)
+        fd, xml_file_path = mkstemp(prefix='frepple_inbound_xml_', dir="/tmp")
+        f = open(xml_file_path, 'w')
+        f.write(xml_content)
+        f.close()
+        os.close(fd)
+        return xml_content, xml_file_path
+
+    @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
+    def test_ordertype_mo(self):
+        """ Tests an input XML that creates a new move and a new picking.
+        """
+        mrpProduction = self.env['mrp.production']
+
+        ref = 'ref-001'
+        qty = 100
+
+        self.assertFalse(mrpProduction.search([('origin', '=', "frePPLe")]))
+
+        _, xml_file = self._create_xml(
+            ref, self.product, self.bom, self.source_loc, self.dest_loc, qty=qty)
+        f = open(xml_file, 'r')
+        self.importer.datafile = f
+        self.importer.company = self.env.user.company_id
+        self.importer.run()
+        f.close()
+
+        mrp_production = mrpProduction.search([('origin', '=', "frePPLe")])
+        self.assertEqual(len(mrp_production), 1)
+        self.assertEqual(mrp_production.move_raw_ids.mapped('product_id.name'), self.bom.mapped('bom_line_ids.product_id.name'))

--- a/frepple/views/mrp_production.xml
+++ b/frepple/views/mrp_production.xml
@@ -1,0 +1,14 @@
+<odoo>
+
+    <record id="mrp_workcenter_inherit_form" model="ir.ui.view">
+        <field name="name">mrp.production.form</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+            <field name="reservation_state" position="after">
+                <field name="frepple_reference" invisible="1"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
…alling to onchange of bom_id so it wasn't creating the components from the bom.

Creating test for it, and logic with error handling to create MO fixing that issue.
Adding also frepple_reference to update/create MO if it already was created before from frepple or not

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12719">[bt#12719] [mt#1044] Frepple: Not All Manufacturing Orders Are Exported (+ Small CR)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py, .xml</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->