### PR TITLE
[bt#12719] Further improvements in Frepple

### DIFF
--- a/frepple/tests/test_inbound_ordertype_do.py
+++ b/frepple/tests/test_inbound_ordertype_do.py
@@ -212,7 +212,7 @@ class TestInboundOrdertypeDo(TestBase):
         ]), picking)
 
         _, xml_file = self._create_xml(
-            ref, self.product, self.source_loc, self.dest_loc, qty=qty + 7)
+            ref, self.product, self.source_loc, self.dest_loc, qty=qty + 7, datetime_xml=datetime_str_odoo)
         f = open(xml_file, 'r')
         self.importer.datafile = f
         self.importer.company = self.env.user.company_id

--- a/frepple/tests/test_inbound_ordertype_mo.py
+++ b/frepple/tests/test_inbound_ordertype_mo.py
@@ -24,6 +24,10 @@ class TestInboundOrdertypeDo(TestBase):
         self.bom = self._create_bom(self.product, [self.sub_product_1, self.sub_product_2])
         self.dest_loc = self._create_location('ASM/Stock')
         self.source_loc = self._create_location('Source Location')
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.lot_stock_id = self.dest_loc
+        warehouse.manu_type_id.default_location_src_id = self.source_loc
+        warehouse.manu_type_id.default_location_dest_id = self.dest_loc
 
     def _create_xml(self, reference, product, bom, source_location, destination_location, qty, datetime_xml=None):
         if datetime_xml is None:
@@ -103,4 +107,9 @@ class TestInboundOrdertypeDo(TestBase):
 
         mrp_production = mrpProduction.search([('origin', '=', "frePPLe")])
         self.assertEqual(len(mrp_production), 1)
+        self.assertEqual(mrp_production.picking_type_id.code, 'mrp_operation')
+        self.assertEqual(mrp_production.picking_type_id.warehouse_id.lot_stock_id.id, self.dest_loc.id)
+        self.assertEqual(mrp_production.location_src_id.complete_name, self.source_loc.name)
+        self.assertEqual(mrp_production.location_dest_id.complete_name, self.dest_loc.name)
         self.assertEqual(mrp_production.move_raw_ids.mapped('product_id.name'), self.bom.mapped('bom_line_ids.product_id.name'))
+        self.assertEqual(mrp_production.move_raw_ids.mapped('product_uom_qty'), [qty, qty])


### PR DESCRIPTION
MO outbound
- Not generating MO having a negative qty in the components
- Adding missing operation tag in the MO
- Picking type added as that matching the received location. Locations are set according to it
- Bugfixing the resulting qty thanks to call onchanges in the right order when using Form
- Adding checks in the tests to check quantities of components, locations, picking type, etc
DO outbound
- Skipping DOs having the same origin and destination
DO inbound tests
- Fixing a test failing due to small differences in dates as we are not reusing the same date of the created picking
Items outbound
- Adapting test to new export logic that exports supplier info for each seller for all rules in which the product has a route. Removing some redundancy in tests