### PR TITLE
[bt#12719] IMP better exclude

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1061,7 +1061,7 @@ class exporter(object):
         m = self.env["mrp.production"]
         sml = self.env["stock.move.line"]
         # Adapting search to some existing states in v13
-        recs = m.search([("state", "in", ["confirmed", "planned", "progress", "to_close"])])
+        recs = m.search([("state", "not in", ["draft", "done", "cancel"])])
         fields = [
             "bom_id",
             "date_start",


### PR DESCRIPTION
this is because edi adds more states and we want to export them without having to have a bridge

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12719">[bt#12719] [mt#1044] Frepple: Not All Manufacturing Orders Are Exported (+ Small CR)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->