### PR TITLE
[bt#12719] Changing outbound from move lines to moves. Adapting tests…

### DIFF
--- a/frepple/models/stock_move.py
+++ b/frepple/models/stock_move.py
@@ -28,11 +28,10 @@ class StockMove(models.Model):
         StockPicking = self.env['stock.picking']
         ProductProduct = self.env['product.product']
         StockLocation = self.env['stock.location']
-        StockWarehouse = self.env['stock.warehouse']
         UomUom = self.env['uom.uom']
 
         elem_reference = elem.get('reference')
-        elem_date = (elem.get('start') or elem.get('end', '')).replace('T', ' ')
+        elem_date = (elem.get('start')).replace('T', ' ')
         uom_id, item_id = elem.get("item_id").split(",")
 
         # If we find at least one error, we inform and skip the element update/creation.
@@ -81,9 +80,10 @@ class StockMove(models.Model):
 
                 # no need to set location_id and location_dest_id as they are set from picking type
                 # with onchange
+                # No need to set scheduled_date as elem_date, as it will take automatically the earliest date
+                # from all move expected dates
                 picking_values = [
                     ['picking_type_id', picking_type_id],
-                    ['scheduled_date', elem_date],
                     ['origin', 'frePPLe']
                 ]
                 f_picking = Form(StockPicking)
@@ -101,7 +101,7 @@ class StockMove(models.Model):
                 ['product_id', product],
                 ['product_uom', uom],
                 ['product_uom_qty', elem.get('quantity')],
-                ['date_expected', elem_date],  # Not sure Matt
+                ['date_expected', elem_date],
                 ['frepple_reference', elem_reference],
                 ['location_id', from_location],     # Should be automatically set by picking type
                 ['location_dest_id', to_location],  # Should be automatically set by picking type

--- a/frepple/tests/__init__.py
+++ b/frepple/tests/__init__.py
@@ -5,14 +5,14 @@
 # See LICENSE file for full licensing details.
 ##############################################################################
 
-from . import test_outbound_customers
-from . import test_outbound_items
-from . import test_outbound_locations
-from . import test_outbound_move_lines
-from . import test_outbound_stock_rules
-from . import test_outbound_saleorders
+# from . import test_outbound_customers
+# from . import test_outbound_items
+# from . import test_outbound_locations
+# from . import test_outbound_moves
+# from . import test_outbound_stock_rules
+# from . import test_outbound_saleorders
 from . import test_inbound_ordertype_po
-from . import test_inbound_ordertype_do
-from . import test_inbound_ordertype_mo
-from . import test_stock_location
-from . import test_tree
+# from . import test_inbound_ordertype_do
+# from . import test_inbound_ordertype_mo
+# from . import test_stock_location
+# from . import test_tree

--- a/frepple/tests/__init__.py
+++ b/frepple/tests/__init__.py
@@ -5,14 +5,14 @@
 # See LICENSE file for full licensing details.
 ##############################################################################
 
-# from . import test_outbound_customers
-# from . import test_outbound_items
-# from . import test_outbound_locations
-# from . import test_outbound_moves
-# from . import test_outbound_stock_rules
-# from . import test_outbound_saleorders
+from . import test_outbound_customers
+from . import test_outbound_items
+from . import test_outbound_locations
+from . import test_outbound_moves
+from . import test_outbound_stock_rules
+from . import test_outbound_saleorders
 from . import test_inbound_ordertype_po
-# from . import test_inbound_ordertype_do
-# from . import test_inbound_ordertype_mo
-# from . import test_stock_location
-# from . import test_tree
+from . import test_inbound_ordertype_do
+from . import test_inbound_ordertype_mo
+from . import test_stock_location
+from . import test_tree

--- a/frepple/tests/test_base.py
+++ b/frepple/tests/test_base.py
@@ -124,21 +124,26 @@ class TestBase(TransactionCase):
             'bom_line_ids': bom_line_ids
         })
 
-    def _create_supplier_seller(self, name, product, priority, price, delay):
-        supplier = self.env['res.partner'].create({
-            'name': name,
-            'supplier_rank': 1,
-        })
+    def _create_seller(self, supplier, product, priority, price, delay, date_start, date_end):
         seller = self.env['product.supplierinfo'].create({
             'name': supplier.id,
             'product_id': product.id,
             'product_tmpl_id': product.product_tmpl_id.id,
-            'currency_id': self.env.ref('base.EUR').id,
             'min_qty': 0.0,
             'sequence': priority,
             'price': price,
             'delay': delay,
+            'date_start': date_start,
+            'date_end': date_end,
         })
+        return seller
+
+    def _create_supplier_seller(self, name, product, priority, price, delay, date_start=False, date_end=False):
+        supplier = self.env['res.partner'].create({
+            'name': name,
+            'supplier_rank': 1,
+        })
+        seller = self._create_seller(supplier, product, priority, price, delay, date_start, date_end)
         return supplier, seller
 
     def _create_warehouse(self, name, values=None):

--- a/frepple/tests/test_inbound_ordertype_po.py
+++ b/frepple/tests/test_inbound_ordertype_po.py
@@ -10,6 +10,7 @@ import os
 from unittest import skipIf
 from odoo.addons.frepple.tests.test_base import TestBase
 from odoo import fields
+from dateutil.relativedelta import relativedelta
 
 UNDER_DEVELOPMENT = False
 UNDER_DEVELOPMENT_MSG = 'Test skipped because of being under development'
@@ -19,8 +20,14 @@ class TestInboundOrdertypePo(TestBase):
     def setUp(self):
         super(TestInboundOrdertypePo, self).setUp()
         self.product = self._create_product('Main Product', price=2)
-        self.supplier, _ = self._create_supplier_seller(
-            'Supplier_1', product=self.product, priority=1, price=7, delay=3)
+        date_now = fields.Datetime.now()
+        self.supplier, self.seller = self._create_supplier_seller(
+            'Supplier_1', product=self.product, priority=1, price=7, delay=3,
+            date_start=date_now - relativedelta(days=1),
+            date_end=False)
+        self.seller2 = self._create_seller(self.supplier, self.product, priority=1, price=5, delay=5,
+                                           date_start=date_now + relativedelta(days=1),
+                                           date_end=date_now + relativedelta(days=3))
         self.dest_loc = self._create_location('ASM/Stock')
         self.source_loc = self._create_location('Source Location')
         warehouse = self.env.ref('stock.warehouse0')
@@ -38,7 +45,7 @@ class TestInboundOrdertypePo(TestBase):
                      <operationplans>
                         <operationplan 
                         ordertype="PO" 
-                        id="186182389105" 
+                        reference="186182389105" 
                         item="CAFE ROYAL NS Alu Espresso x36 x5"                        
                         item_id="1,2577"  
                         location="ASM/Stock"  
@@ -57,7 +64,7 @@ class TestInboundOrdertypePo(TestBase):
                 <operationplans>
                     <operationplan  
                       ordertype="PO"
-                      id="{id}"
+                      reference="{reference}"
                       item="{product_name}" 
                       item_id="{uom_id},{product_id}"
                       start="{datetime}" 
@@ -72,7 +79,7 @@ class TestInboundOrdertypePo(TestBase):
                     />
                 </operationplans>
             </plan>
-        '''.format(id=reference,
+        '''.format(reference=reference,
                    product_name=product.name,
                    product_id=product.id,
                    location_name=destination_location.name,
@@ -101,8 +108,15 @@ class TestInboundOrdertypePo(TestBase):
 
         self.assertFalse(purchaseOrder.search([('origin', '=', "frePPLe")]))
 
+        # The PO line will be planned for 2 days after the PO is created.
+        # That's important as we have a supplier with a different pricing between the day after and 3 days
+        # after the PO was created, then that supplier will be chosen and we do some checks about pricing
+        datetime_str_odoo = fields.Datetime.to_string(fields.Datetime.now() + relativedelta(days=2))
+        datetime_str_xml = datetime_str_odoo.replace(' ', 'T')
+
         _, xml_file = self._create_xml(
-            ref, self.product, self.supplier, self.source_loc, self.dest_loc, qty=qty)
+            ref, self.product, self.supplier, self.source_loc, self.dest_loc, qty=qty,
+            datetime_xml=datetime_str_xml)
         f = open(xml_file, 'r')
         self.importer.datafile = f
         self.importer.company = self.env.user.company_id
@@ -114,3 +128,10 @@ class TestInboundOrdertypePo(TestBase):
         self.assertEqual(po.order_line.product_id.name, self.product.name)
         self.assertEqual(po.order_line.product_qty, qty)
         self.assertEqual(po.order_line.product_uom.id, self.product.uom_id.id)
+        # The planned date of the PO line is respected to that specified by frepple, instead of changing
+        # to another taking into account the delay of the supplier and the date order of the PO
+        self.assertEqual(fields.Datetime.to_string(po.order_line.date_planned), datetime_str_odoo)
+        # The price is finally assigned as the one of the supplier according to the planned date of the line,
+        # unlike in standard odoo where it should be according to the PO order date
+        self.assertEqual(po.order_line.price_unit, self.seller2.price)
+        self.assertEqual(po.order_line.frepple_reference, ref)

--- a/frepple/tests/test_outbound_moves.py
+++ b/frepple/tests/test_outbound_moves.py
@@ -24,13 +24,13 @@ class TestOutboundMoveLines(TestBase):
         """
         location = self._create_location('Origin Location #1')
         product = self._create_product('Product #1', price=7)
-        self._create_move_line(location, location, product)
+        self._create_move(location, location, product)
 
         self.assertEqual(self.env.user.company_id.internal_moves_domain, '[]')
-        xml_str_actual = self.exporter.export_move_lines(
-            ctx={'test_export_move_lines': True, 'test_prefix': 'TC_'})
+        xml_str_actual = self.exporter.export_moves(
+            ctx={'test_export_moves': True, 'test_prefix': 'TC_'})
         xml_str_expected = '\n'.join([
-            '<!-- Stock Move Lines -->',
+            '<!-- Stock Moves -->',
             '<operationplans>',
             '</operationplans>',
         ])
@@ -49,17 +49,17 @@ class TestOutboundMoveLines(TestBase):
         warehouse_dest.lot_stock_id = dest_location
 
         product = self._create_product('Product #1', price=7)
-        move_line = self._create_move_line(orig_location, dest_location, product)
+        move = self._create_move(orig_location, dest_location, product)
 
         self.assertEqual(self.env.user.company_id.internal_moves_domain, '[]')
-        xml_str_actual = self.exporter.export_move_lines(
-            ctx={'test_export_move_lines': True, 'test_prefix': 'TC_'})
+        xml_str_actual = self.exporter.export_moves(
+            ctx={'test_export_moves': True, 'test_prefix': 'TC_'})
         xml_str_expected = '\n'.join([
-            '<!-- Stock Move Lines -->',
+            '<!-- Stock Moves -->',
             '<operationplans>',
             '<operationplan ordertype="DO" reference="{}" start="{}" quantity="1.0" status="proposed">'.format(
-                move_line.id,
-                fields.Datetime.context_timestamp(move_line, move_line.date).strftime("%Y-%m-%dT%H:%M:%S"),
+                move.id,
+                fields.Datetime.context_timestamp(move, move.date).strftime("%Y-%m-%dT%H:%M:%S"),
             ),
             '<item name="{product_name}" subcategory="{subcategory}" description="Product"/>'.format(
                 product_name=product.name, subcategory='{},{}'.format(self.kgm_uom.id, product.id)),
@@ -94,18 +94,18 @@ class TestOutboundMoveLines(TestBase):
 
         product_1 = self._create_product('Product #1', price=7)
         product_2 = self._create_product('Product #2', price=13)
-        move_line_1 = self._create_move_line(orig_location_1, dest_location_1, product_1)
-        move_line_2 = self._create_move_line(orig_location_2, dest_location_2, product_2)
+        move_1 = self._create_move(orig_location_1, dest_location_1, product_1)
+        move_2 = self._create_move(orig_location_2, dest_location_2, product_2)
 
         self.assertEqual(self.env.user.company_id.internal_moves_domain, '[]')
-        xml_str_actual_1 = self.exporter.export_move_lines(
-            ctx={'test_export_move_lines': True, 'test_prefix': 'TC_'})
+        xml_str_actual_1 = self.exporter.export_moves(
+            ctx={'test_export_moves': True, 'test_prefix': 'TC_'})
         xml_str_expected_1 = '\n'.join([
-            '<!-- Stock Move Lines -->',
+            '<!-- Stock Moves -->',
             '<operationplans>',
             '<operationplan ordertype="DO" reference="{}" start="{}" quantity="1.0" status="proposed">'.format(
-                move_line_1.id,
-                fields.Datetime.context_timestamp(move_line_1, move_line_1.date).strftime("%Y-%m-%dT%H:%M:%S"),
+                move_1.id,
+                fields.Datetime.context_timestamp(move_1, move_1.date).strftime("%Y-%m-%dT%H:%M:%S"),
             ),
             '<item name="{product_name}" subcategory="{subcategory}" description="Product"/>'.format(
                 product_name=product_1.name, subcategory='{},{}'.format(self.kgm_uom.id, product_1.id)),
@@ -115,8 +115,8 @@ class TestOutboundMoveLines(TestBase):
                 location_name=orig_location_1.complete_name, location_id=orig_location_1.id),
             '</operationplan>',
             '<operationplan ordertype="DO" reference="{}" start="{}" quantity="1.0" status="proposed">'.format(
-                move_line_2.id,
-                fields.Datetime.context_timestamp(move_line_2, move_line_2.date).strftime("%Y-%m-%dT%H:%M:%S"),
+                move_2.id,
+                fields.Datetime.context_timestamp(move_2, move_2.date).strftime("%Y-%m-%dT%H:%M:%S"),
             ),
             '<item name="{product_name}" subcategory="{subcategory}" description="Product"/>'.format(
                 product_name=product_2.name, subcategory='{},{}'.format(self.kgm_uom.id, product_2.id)),
@@ -130,14 +130,14 @@ class TestOutboundMoveLines(TestBase):
         self.assertEqual(xml_str_actual_1, xml_str_expected_1)
 
         self.env.user.company_id.internal_moves_domain = "[('product_id', '=', {})]".format(product_1.id)
-        xml_str_actual_2 = self.exporter.export_move_lines(
-            ctx={'test_export_move_lines': True, 'test_prefix': 'TC_'})
+        xml_str_actual_2 = self.exporter.export_moves(
+            ctx={'test_export_moves': True, 'test_prefix': 'TC_'})
         xml_str_expected_2 = '\n'.join([
-            '<!-- Stock Move Lines -->',
+            '<!-- Stock Moves -->',
             '<operationplans>',
             '<operationplan ordertype="DO" reference="{}" start="{}" quantity="1.0" status="proposed">'.format(
-                move_line_1.id,
-                fields.Datetime.context_timestamp(move_line_1, move_line_1.date).strftime("%Y-%m-%dT%H:%M:%S"),
+                move_1.id,
+                fields.Datetime.context_timestamp(move_1, move_1.date).strftime("%Y-%m-%dT%H:%M:%S"),
             ),
             '<item name="{product_name}" subcategory="{subcategory}" description="Product"/>'.format(
                 product_name=product_1.name, subcategory='{},{}'.format(self.kgm_uom.id, product_1.id)),


### PR DESCRIPTION
… of DO

Change for PO lines so that the unit price is taken according to the planned date of the line, not from the order date of the PO.
The PO order date will be the earliest planned date of its lines. Adapting tests of PO

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=12719">[bt#12719] [mt#1044] Frepple: Not All Manufacturing Orders Are Exported (+ Small CR)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->