### PR TITLE
[bt#13668] Changes of location name for POs outbound

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1019,9 +1019,8 @@ class exporter(object):
             if j["state"] == "done":
                 continue
 
-            location_name = self.env['res.company'].search([
-                ('name', '=', self.company),
-            ], limit=1).manufacturing_warehouse.lot_stock_id.complete_name or self.company
+            location_name = \
+                self.env['purchase.order'].browse(j["id"]).picking_type_id.warehouse_id.lot_stock_id.get_warehouse_stock_location().complete_name
             # location = self.mfg_location  # Original frePPLe code.
             if location_name and item and i["product_qty"] > i["qty_received"]:
                 start = odoo_fields.Datetime.context_timestamp(m, j["date_order"]).strftime("%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
No update is needed
- frepple

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13668">[bt#13668] [mt#xxx] Frepple: POs Are Exported with the Location of the Warehouse Where We Manufacture, Instead Should be the Location We Purchase to</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->