### PR TITLE
[bt#13660] Inbound PO receive frepple reference as "id" instead of "r…

### DIFF
--- a/frepple/controllers/inbound.py
+++ b/frepple/controllers/inbound.py
@@ -58,10 +58,12 @@ class importer(object):
         # from the dictionary of imported pos
         recs = self.env["purchase.order"].search([("state", "=", "draft"),
                                                   ("origin", "=", "frePPLe")])
+        recs.button_cancel()
         recs.unlink()
         for rec in recs:
-            rec_key = list(self.imported_pos.keys())[list(self.imported_pos.values()).index(rec.id)]
-            del self.imported_pos[rec_key]
+            if len(self.imported_pos) > 0:
+                rec_key = list(self.imported_pos.keys())[list(self.imported_pos.values()).index(rec.id)]
+                del self.imported_pos[rec_key]
         return recs
 
     def _cancel_draft_frepple_MOs(self):
@@ -78,8 +80,9 @@ class importer(object):
                                                  ("origin", "=", "frePPLe")])
         recs.unlink()
         for rec in recs:
-            rec_key = list(self.imported_pickings.keys())[list(self.imported_pickings.values()).index(rec.id)]
-            del self.imported_pickings[rec_key]
+            if len(self.imported_pickings) > 0:
+                rec_key = list(self.imported_pickings.keys())[list(self.imported_pickings.values()).index(rec.id)]
+                del self.imported_pickings[rec_key]
         return recs
 
     def run(self):

--- a/frepple/models/purchase_order_line.py
+++ b/frepple/models/purchase_order_line.py
@@ -26,7 +26,7 @@ class PurchaseOrderLine(models.Model):
         else:
             date_planned = received_date
         frepple_reference_list = po_line.frepple_reference.split(',')
-        frepple_reference_list.append(elem.get('reference'))
+        frepple_reference_list.append(elem.get('id'))
         frepple_reference = ','.join(frepple_reference_list)
         return [
             ["product_qty", po_line.product_qty + float(elem.get("quantity"))],
@@ -42,7 +42,7 @@ class PurchaseOrderLine(models.Model):
             ["product_qty", elem.get("quantity")],
             ["product_uom", uom],
             ["date_planned", (elem.get('start')).replace('T', ' ')],
-            ["frepple_reference", elem.get('reference')]
+            ["frepple_reference", elem.get('id')]
         ]
 
     def _change_price_according_to_date_planned(self):
@@ -89,7 +89,7 @@ class PurchaseOrderLine(models.Model):
         # If we find at least one error, we inform and skip the element update/creation.
         errors = []
 
-        elem_reference = elem.get('reference')
+        elem_reference = elem.get('id')
         uom_id, item_id = elem.get("item_id").split(",")
 
         supplier_id = int(elem.get("supplier").split(" ", 1)[0])
@@ -164,7 +164,7 @@ class PurchaseOrderLine(models.Model):
 
             # The unit price is changed to that of the supplier according to the planned date of the line.
             # In the core it has been computed according to the PO order date
-            po_line = po.order_line.filtered(lambda x: elem.get('reference') in x.frepple_reference)
+            po_line = po.order_line.filtered(lambda x: elem.get('id') in x.frepple_reference)
             po_line._change_price_according_to_date_planned()
 
             # The PO order date will be the earliest planned date of the po lines

--- a/frepple/tests/test_base_inbound_ordertype_po.py
+++ b/frepple/tests/test_base_inbound_ordertype_po.py
@@ -41,7 +41,7 @@ class TestBaseInboundOrdertypePo(TestBase):
         xml_content = '''
                     <operationplan  
                       ordertype="PO"
-                      reference="{reference}"
+                      id="{reference}"
                       item="{product_name}" 
                       item_id="{uom_id},{product_id}"
                       start="{datetime}" 
@@ -93,7 +93,7 @@ class TestBaseInboundOrdertypePo(TestBase):
                 <operationplans>'''
         xml_lines = []
         for item in lines:
-            xml_line = self._create_xml_line(item['reference'], item['product'], item['supplier'],
+            xml_line = self._create_xml_line(item['id'], item['product'], item['supplier'],
                                              item['source_location'], item['destination_location'],
                                              item['qty'], item['datetime_xml'])
             xml_lines.append(xml_line)
@@ -133,7 +133,7 @@ class TestBaseInboundOrdertypePo(TestBase):
         datetime_str_xml = datetime_str_odoo.replace(' ', 'T')
 
         _, xml_file = self._create_xml(
-            [{'reference': ref, 'product': self.product, 'supplier': self.supplier,
+            [{'id': ref, 'product': self.product, 'supplier': self.supplier,
               'source_location': self.source_loc, 'destination_location': self.dest_loc, 'qty': qty,
               'datetime_xml': datetime_str_xml}]
         )
@@ -184,13 +184,13 @@ class TestBaseInboundOrdertypePo(TestBase):
         datetime_str_xml_2 = datetime_str_odoo_2.replace(' ', 'T')
 
         _, xml_file = self._create_xml(
-            [{'reference': ref_product2, 'product': self.product2, 'supplier': self.supplier,
+            [{'id': ref_product2, 'product': self.product2, 'supplier': self.supplier,
               'source_location': self.source_loc, 'destination_location': self.dest_loc, 'qty': qty_product2,
               'datetime_xml': datetime_str_xml_1},
-             {'reference': ref_1, 'product': self.product, 'supplier': self.supplier,
+             {'id': ref_1, 'product': self.product, 'supplier': self.supplier,
               'source_location': self.source_loc, 'destination_location': self.dest_loc, 'qty': qty_1,
               'datetime_xml': datetime_str_xml_1},
-             {'reference': ref_2, 'product': self.product, 'supplier': self.supplier,
+             {'id': ref_2, 'product': self.product, 'supplier': self.supplier,
               'source_location': self.source_loc, 'destination_location': self.dest_loc, 'qty': qty_2,
               'datetime_xml': datetime_str_xml_2}]
         )

--- a/frepple/tests/test_inbound_ordertype_po.py
+++ b/frepple/tests/test_inbound_ordertype_po.py
@@ -7,6 +7,8 @@
 
 from unittest import skipIf
 from odoo.addons.frepple.tests.test_base_inbound_ordertype_po import TestBaseInboundOrdertypePo
+#from tempfile import mkstemp
+#import os
 
 UNDER_DEVELOPMENT = False
 UNDER_DEVELOPMENT_MSG = 'Test skipped because of being under development'
@@ -29,3 +31,30 @@ class TestInboundOrdertypePo(TestBaseInboundOrdertypePo):
             received lines, as they are for the same vendor and product
         """
         self._ordertype_po_many_lines()
+
+    # Use this test for copying the resulting xml from frepple s201 and test it in MindFR Test db, instead of
+    # on an empty db for tests
+    # def test_fake(self):
+    #     xml_content = '''<?xml version="1.0" encoding="UTF-8" ?><plan
+    #     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"><operationplans><operationplan ordertype="PO"
+    #     id="186182378745" item="BISCH CRF Sauce Echalotte 300 ml x12" location="ASM/Stock" supplier="2401
+    #     BISCHOFSZELL NAHRUNGSMITTEL AG" start="2021-02-21 00:00:00" end="2021-02-22 00:00:00"
+    #     quantity="600.00000000" location_id="8" item_id="1,2650" criticality="0"/><operationplan ordertype="PO"
+    #     id="186182378751" item="BISCH CRF Sauce Echalotte 300 ml x12" location="ASM/Stock" supplier="2401
+    #     BISCHOFSZELL NAHRUNGSMITTEL AG" start="2021-03-24 23:00:00" end="2021-03-25 23:00:00"
+    #     quantity="48.00000000" location_id="8" item_id="1,2650" criticality="91"/><operationplan ordertype="PO"
+    #     id="186182378816" item="BISCH CRF Sauce Echalotte 300 ml x12" location="ASM/Stock" supplier="2401
+    #     BISCHOFSZELL NAHRUNGSMITTEL AG" start="2022-05-19 00:00:00" end="2022-05-20 00:00:00"
+    #     quantity="48.00000000" location_id="8" item_id="1,2650" criticality="999"/></operationplans></plan>
+    #     '''
+    #     fd, xml_file_path = mkstemp(prefix='frepple_inbound_xml_', dir="/tmp")
+    #     f = open(xml_file_path, 'w')
+    #     f.write(xml_content)
+    #     f.close()
+    #     os.close(fd)
+    #
+    #     f = open(xml_file_path, 'r')
+    #     self.importer.datafile = f
+    #     self.importer.company = self.env.user.company_id
+    #     self.importer.run()
+    #     f.close()


### PR DESCRIPTION
…eference"

Preventing errors when cancelling POs and MOs when receiving a new import

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13660">[bt#13660] [mt1434] Frepple Connector Inbound: Merge Purchase Order Lines in Same Purchase Order</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->