### PR TITLE
[bt#13983] frePPLe improvements

### DIFF
--- a/frepple/__manifest__.py
+++ b/frepple/__manifest__.py
@@ -12,6 +12,7 @@
         "product",
         "purchase",
         "sale",
+        "sale_stock",
         "resource",
         "mrp",
         'stock',

--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1126,12 +1126,14 @@ class exporter(object):
                     # in case qty <= 0 we should not output that MO at all
                     if qty <= 0:
                         continue
+
+                location_dest = self.env['stock.location'].browse(i['location_dest_id'])
                 yield '<operationplan type="MO" reference=%s start="%s" quantity="%s" status="confirmed"><operation name=%s/><location name=%s/></operationplan>\n' % (
                     quoteattr(i["name"]),
                     odoo_fields.Datetime.context_timestamp(m, startdate).strftime("%Y-%m-%dT%H:%M:%S"),
                     qty,
                     quoteattr(operation),
-                    quoteattr(i["location_dest_id"][1])
+                    quoteattr(location_dest.get_warehouse_stock_location().complete_name)
                 )
         yield "</operationplans>\n"
 

--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -593,7 +593,7 @@ class exporter(object):
                 xml_str.extend([
                     '<itemsupplier leadtime="P{}D" priority="{}" size_minimum="{:.6f}" '
                     'cost="{:0.6f}"{}{}>'.format(
-                        supplier.delay, supplier.sequence, supplier.min_qty or 0, supplier.price,
+                        supplier.delay, supplier.sequence or 1, supplier.min_qty or 0, supplier.price,
                         effective_end_str, effective_start_str),
                     '<location name="{}"/>'.format(rule.location_id.complete_name),
                     '<supplier name={}/>'.format(quoteattr(supplier_name)),

--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -129,6 +129,7 @@ class exporter(object):
             "calendar",
             "manufacturing_warehouse",
             "tz_for_exporting",
+            "frepple_export_language",
         ]
         self.company_id = 0
         for i in recs.read(fields):
@@ -146,6 +147,8 @@ class exporter(object):
             )
             ctx = self.env.context.copy()
             ctx['tz'] = i["tz_for_exporting"]
+            if i["frepple_export_language"]:
+                ctx['lang'] = self.env['res.lang'].browse(i["frepple_export_language"][0]).code
             self.env.context = frozendict(ctx)
         if not self.company_id:
             logger.warning("Can't find company '%s'" % self.company)

--- a/frepple/models/res_company.py
+++ b/frepple/models/res_company.py
@@ -40,6 +40,9 @@ class ResCompany(models.Model):
     def _get_default_frepple_bom_dummy_route_id(self):
         return self.env.ref('frepple.dummy_mrp_routing_frepple', raise_if_not_found=False)
 
+    def _frepple_export_language(self):
+        return self.env['res.lang'].search([], limit=1)
+
     manufacturing_warehouse = fields.Many2one(
         "stock.warehouse", "Manufacturing warehouse", ondelete="set null"
     )
@@ -62,6 +65,11 @@ class ResCompany(models.Model):
     tz_for_exporting = fields.Selection(
         _tz_get, string='Timezone for exporting frePPLe', required=True, default='UTC',
     )
+    frepple_export_language = fields.Many2one(
+        'res.lang', string='Export Language', required=True,
+        default=lambda self: self._frepple_export_language(),
+        help='The language set here is the one that will be used '
+             'to export the content using frePPLe.')
 
     @api.model
     def getFreppleURL(self, navbar=True, _url="/"):

--- a/frepple/views/res_company.xml
+++ b/frepple/views/res_company.xml
@@ -18,6 +18,7 @@
                         <field name="internal_moves_domain" widget="domain" options="{'model': 'stock.move'}"/>
                         <field name="stock_rules_domain" widget="domain" options="{'model': 'stock.rule'}"/>
                         <field name="tz_for_exporting"/>
+                        <field name="frepple_export_language"/>
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION
Make sure suppliers for product have a priority:
The priority is taken from the sequence, but it can be that
it is not set, and in that case it's value is zero. We make
sure it is at least one when exporting it.

Use stock locations for <operationplan> in MO:
The destination location for manufacturing orders was the
name of the location. We want to use the full name of the
stock location of the warehouse in which the original
location is. Same as done in the new version of the code.

Export data in the language defined in the company:
A new field was added to the company's configuration to indicate
the language in which frePPLe exports its data.


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13983">[bt#13983] [mt#1808] MIFR PROD Frepple: Wrong Locations on MO from Odoo, Wrong Translation</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.xml, .py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->