### PR TITLE
[bt#13983][FIX] Use an ID to browse a record

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1130,7 +1130,7 @@ class exporter(object):
                     if qty <= 0:
                         continue
 
-                location_dest = self.env['stock.location'].browse(i['location_dest_id'])
+                location_dest = self.env['stock.location'].browse(i['location_dest_id'][0])
                 yield '<operationplan type="MO" reference=%s start="%s" quantity="%s" status="confirmed"><operation name=%s/><location name=%s/></operationplan>\n' % (
                     quoteattr(i["name"]),
                     odoo_fields.Datetime.context_timestamp(m, startdate).strftime("%Y-%m-%dT%H:%M:%S"),


### PR DESCRIPTION
Before a tuple returned by a read() was used, because of the
queried record being a relational field. So (id, name) was
returned instead.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13983">[bt#13983] [mt#1808] MIFR PROD Frepple: Wrong Locations on MO from Odoo, Wrong Translation</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->