### PR TITLE
[bt#13983][FIX] Translations are considered when exporting

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -365,7 +365,7 @@ class exporter(object):
             We filter on res.partner where customer = True.
         """
         ctx = ctx if ctx else {}
-        return self.env['res.partner'].with_context(ctx)._frepple_export_customers()
+        return self.env['res.partner'].with_context(**ctx)._frepple_export_customers()
 
     def export_suppliers(self):
         """
@@ -958,7 +958,7 @@ class exporter(object):
         (if sale.order.picking_policy = 'one' then same as demand.quantity else 1) -> demand.minshipment
         """
         ctx = ctx if ctx else {}
-        return self.env['sale.order.line'].with_context(ctx)._frepple_export()
+        return self.env['sale.order.line'].with_context(**ctx)._frepple_export()
 
     def export_purchaseorders(self):
         """

--- a/frepple/tests/test_base.py
+++ b/frepple/tests/test_base.py
@@ -18,6 +18,8 @@ class TestBase(TransactionCase):
     def setUp(self):
         super(TestBase, self).setUp()
         self.exporter = exporter(req=self, uid=SUPERUSER_ID)
+        self.company = self.env["res.company"].search([], limit=1)
+        self.exporter.company = self.company.name
 
         self.httprequest = lambda: None  # See https://stackoverflow.com/a/2827734
         self.httprequest.files = {'frePPLe plan': False}
@@ -36,6 +38,13 @@ class TestBase(TransactionCase):
         self.exporter.uom_categories = {
             self.kgm_uom.category_id.id: self.kgm_uom.id,
         }
+
+    def _set_export_language(self, lang_code):
+        """Set the language of the export"""
+        self.env['res.lang'].load_lang(lang_code)
+        self.assertIn(lang_code, [lang[0] for lang in self.env['res.lang'].get_available()])
+        lang = self.env['res.lang']._lang_get(lang_code)
+        self.company.write({'frepple_export_language': lang})
 
     def _create_move(self, from_location, to_location, product, defaults=None):
         defaults_move = defaults if defaults else {}

--- a/frepple/tests/test_outbound_items.py
+++ b/frepple/tests/test_outbound_items.py
@@ -77,12 +77,7 @@ class TestOutboundItems(TestBase):
     @skipIf(UNDER_DEVELOPMENT, UNDER_DEVELOPMENT_MSG)
     def test_product_translated(self):
         """ Tests a product with the name translated"""
-        self.env['res.lang'].load_lang('es_ES')
-        self.assertIn('es_ES', [lang[0] for lang in self.env['res.lang'].get_available()])
-        es_lang = self.env['res.lang']._lang_get('es_ES')
-
-        company = self.env["res.company"].search([], limit=1)
-        company.write({'frepple_export_language': es_lang})
+        self._set_export_language('es_ES')
 
         category_a = self._create_category('TC_Category_A')
         product_1 = self._create_product('TC_Product_1', category=category_a, price=5)
@@ -97,7 +92,10 @@ class TestOutboundItems(TestBase):
             'res_id': product_1.product_tmpl_id.id,
         })
 
-        self.exporter.company = company.name
+        # The following must be called always before calling a method for export
+        # in the tests. It is normally called when the endpoint /frepple is reached
+        # but here we have to do it explicitly because we are calling the
+        # particular export methods explicitly. It is needed to load the translations.
         self.exporter.load_company()
         xml_str_actual = self.exporter.export_items(ctx={'test_export_items': True, 'test_prefix': 'TC_'})
         xml_str_expected = '\n'.join([


### PR DESCRIPTION
Before they weren't because of how the with_context() was used,
that replaced the dictionary in which the language was set.
The call to with_context() has been changed so that existing
keys (including that for the language) are kept.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=helpdesk.ticket&id=13983">[bt#13983] [mt#1808] MIFR PROD Frepple: Wrong Locations on MO from Odoo, Wrong Translation</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->