### PR TITLE
[t120325] Accept Child Locations in Operation Type Search

### DIFF
--- a/frepple/__manifest__.py
+++ b/frepple/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     "name": "frepple",
-    "version": "13.0.6.7.3",
+    "version": "13.0.6.7.4",
     "category": "Manufacturing",
     "summary": "Advanced planning and scheduling",
     "author": "frePPLe, brain-tec AG",

--- a/frepple/models/stock_move.py
+++ b/frepple/models/stock_move.py
@@ -72,8 +72,8 @@ class StockMove(models.Model):
 
             if picking_key not in imported_pickings:
                 picking_type_id = self.env['stock.picking.type'].search(
-                    [('default_location_src_id', '=', from_location.id),
-                     ('default_location_dest_id', '=', to_location.id),
+                    [('default_location_src_id', 'child_of', from_location.id),
+                     ('default_location_dest_id', 'child_of', to_location.id),
                      ('code', '=', 'internal')], limit=1)
                 if not picking_type_id:
                     picking_type_id = self.env.ref('stock.picking_type_internal')


### PR DESCRIPTION
this is needed, because for (EDI) reasons the operation type might be pointing to sub-locations which frepple doesn't know about - frepple will always just send the main stock location of a warehouse

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.braintec-group.com/web#view_type=form&model=project.task&id=120325">[t120325] [mt11921] EDI Vente Privée/Mobiltron : <whOutIns> from Internal Movement</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->