### PR TITLE
[t127249] Switching receipt date for inbound PO to end element, inste…

### DIFF
--- a/frepple/models/purchase_order_line.py
+++ b/frepple/models/purchase_order_line.py
@@ -19,7 +19,7 @@ class PurchaseOrderLine(models.Model):
     frepple_reference = fields.Char('Reference (frePPLe)', copy=False)
 
     def _get_po_line_update_values(self, po_line, elem, uom):
-        received_date = elem.get('start').replace('T', ' ')
+        received_date = elem.get('end').replace('T', ' ')
         date_planned = po_line.date_planned
         if date_planned:
             date_planned = min(date_planned, fields.Datetime.from_string(received_date))


### PR DESCRIPTION
…ad of start element

Deploy: No need to update frepple module. Just python changes

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127249">[t127249] [mt13151] frePPLe Connector: Include "Receipt Date" When Creating POs</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->