### PR TITLE
[t127249] Changing logic to compute PO date_planned according to rece…

### DIFF
--- a/frepple/controllers/inbound.py
+++ b/frepple/controllers/inbound.py
@@ -24,7 +24,8 @@ logger = logging.getLogger(__name__)
 
 
 class importer(object):
-    def __init__(self, req, database=None, company=None, mode=1, imported_pos=None, imported_pickings=None):
+    def __init__(self, req, database=None, company=None, mode=1, imported_pos=None, imported_pickings=None,
+                 po_dates=None):
         self.env = req.env
         self.database = database
         self.company = company
@@ -44,6 +45,12 @@ class importer(object):
         if imported_pos is None:
             imported_pos = {}
         self.imported_pos = imported_pos
+
+        # Dictionary that stores as key the PO id and as value the earliest date from the PO lines
+        # to be assigned to the PO for date_planned and date_order.
+        if po_dates is None:
+            po_dates = {}
+        self.po_dates = po_dates
 
         # Dictionary that stores as key the source and destination locations of the picking,
         # and as value the associated picking id.
@@ -112,7 +119,7 @@ class importer(object):
                     order_type = elem.get("ordertype")
 
                     if order_type == "PO":
-                        self._create_or_update_po_line(elem, self.company, self.imported_pos)
+                        self._create_or_update_po_line(elem, self.company, self.imported_pos, self.po_dates)
                         count_po_line += 1
 
                     elif order_type == "DO":
@@ -132,14 +139,21 @@ class importer(object):
                 # Remember the root element
                 root = elem
 
+        PurchaseOrder = self.env['purchase.order']
+        for po_id, dates in self.po_dates.items():
+            po = PurchaseOrder.browse(po_id)
+            po.write({'date_planned': dates['date_planned'],
+                      'date_order': dates['date_order']})
+
         # Be polite, and reply to the post
         msg.append("Processed %s uploaded PO lines" % count_po_line)
         msg.append("Processed %s uploaded Stock Moves" % count_move)
         msg.append("Processed %s uploaded Manufacturing Orders" % count_mo)
         return "\n".join(msg)
 
-    def _create_or_update_po_line(self, elem, company, imported_pos):
-        self.env['purchase.order.line']._create_or_update_from_frepple_po_line(elem, company, imported_pos)
+    def _create_or_update_po_line(self, elem, company, imported_pos, po_dates):
+        self.env['purchase.order.line']._create_or_update_from_frepple_po_line(elem, company, imported_pos,
+                                                                               po_dates)
 
     def _create_or_update_stock_move(self, elem, company, imported_pickings):
         self.env['stock.move']._create_or_update_from_frepple_stock_move(elem, company, imported_pickings)

--- a/frepple/models/purchase_order_line.py
+++ b/frepple/models/purchase_order_line.py
@@ -73,7 +73,7 @@ class PurchaseOrderLine(models.Model):
         self.price_unit = price_unit
 
     @api.model
-    def _create_or_update_from_frepple_po_line(self, elem, company, imported_pos):
+    def _create_or_update_from_frepple_po_line(self, elem, company, imported_pos, po_dates):
         """ Receives an XML subtree from an input file from frePPLe,
             in particular an <operationplan>, and creates a purchase.order.line
             for it inside a PO. A PO is created/selected for each supplier gathering all their PO lines
@@ -167,6 +167,20 @@ class PurchaseOrderLine(models.Model):
             po_line = po.order_line.filtered(lambda x: elem.get('id') in x.frepple_reference)
             po_line._change_price_according_to_date_planned()
 
-            # The PO order date will be the earliest planned date of the po lines
-            if po.date_order > po_line.date_planned:
-                po.date_order = po_line.date_planned
+            # The PO receipt date will be the earliest planned date of the po lines
+            # The PO order date will be the earliest start date of the po lines
+            # Updating the dictionary that will be used in the run method to update the dates in the PO
+            # Otherwise updating the lines from the PO line was causing issues
+            # as the date_planned as soon as it's assigned to the PO makes the PO line date_planned readonly
+            # and the date_order cannot be stored in the PO line, as there it's readonly and related to the one
+            # from the PO
+            date_order = fields.Datetime.from_string(elem.get('start').replace('T', ' '))
+            if po.id not in po_dates:
+                po_dates[po.id] = {'date_planned': po_line.date_planned,
+                                   'date_order': date_order
+                                   }
+            else:
+                if po_dates[po.id]['date_planned'] > po_line.date_planned:
+                    po_dates[po.id].update({'date_planned': po_line.date_planned})
+                if po_dates[po.id]['date_order'] > date_order:
+                    po_dates[po.id].update({'date_order': date_order})

--- a/frepple/tests/test_base_inbound_ordertype_po.py
+++ b/frepple/tests/test_base_inbound_ordertype_po.py
@@ -161,6 +161,8 @@ class TestBaseInboundOrdertypePo(TestBase):
                                self.seller2.product_uom._compute_price(
                                    self.seller2.price, po.order_line.product_uom), 2)
         self.assertEqual(po.order_line.frepple_reference, ref)
+        self.assertEqual(fields.Datetime.to_string(po.date_planned), datetime_end_str_odoo)
+        self.assertEqual(fields.Datetime.to_string(po.date_order), datetime_start_str_odoo)
         return po
 
     def _ordertype_po_many_lines(self):
@@ -225,4 +227,6 @@ class TestBaseInboundOrdertypePo(TestBase):
                                self.seller2.product_uom._compute_price(
                                     self.seller2.price, order_line_summarized.product_uom), 2)
         self.assertEqual(order_line_summarized.frepple_reference, ','.join([ref_1, ref_2]))
+        self.assertEqual(fields.Datetime.to_string(po.date_planned), datetime_end_str_odoo_1)
+        self.assertEqual(fields.Datetime.to_string(po.date_order), datetime_start_str_odoo_1)
         return po


### PR DESCRIPTION
…ived end element, and date_order according to start element

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127249">[t127249] [mt13151] frePPLe Connector: Include "Receipt Date" When Creating POs</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->