### PR TITLE
[t127250] Revert Changing weight to be an attribute instead of an element

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -564,14 +564,15 @@ class exporter(object):
         # UOM used as the reference for the category of the UOM set on the product's template,
         # and then the product's ID. ò_Ó
         ref_uom_for_uom_category_id = self.uom_categories[self.uom[product.product_tmpl_id.uom_id.id]['category']]
-        weight = product._get_weight()
-        xml_str = [
-            '<item name={} cost="{:0.6f}" subcategory="{},{}" description="product" weight="{:0.6f}">'.format(
-                quoteattr(product.name), product.list_price, ref_uom_for_uom_category_id, product.id, weight)]
+        xml_str = ['<item name={} cost="{:0.6f}" subcategory="{},{}" description="product">'.format(
+            quoteattr(product.name), product.list_price, ref_uom_for_uom_category_id, product.id)]
 
         warehouse_domain = []
         if 'test_prefix' in ctx:
             warehouse_domain.append(('code', '=like', '{}%'.format(ctx['test_prefix'])))
+
+        weight = product._get_weight()
+        xml_str.append('<weight>%f</weight>' % weight)
 
         # in the export of product master data the supplierinfo is also exported. to make sure frepple has all
         # the right routes to source the products, we were exporting each supplierinfo once for each warehouse.


### PR DESCRIPTION
This reverts commit bf6fc4ae816286f33ad2f13c75ed6e1d849fe61e.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://odoo.bt-group.com/web#view_type=form&model=project.task&id=127250">[t127250] [mt13136] frePPLe Connector: Include LU Gross Weight</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->