### PR TITLE
[t132054] Fixing frepple_lots tests. When running all modules integra…

### DIFF
--- a/frepple/tests/test_base.py
+++ b/frepple/tests/test_base.py
@@ -224,6 +224,7 @@ class TestBase(TransactionCase):
             'product_id': product.id,
             'lot_id': lot.id if lot else False,
             'inventory_quantity': qty,
+            'inventory_quantity_set': True,
         })
         quant.action_apply_inventory()
         return quant


### PR DESCRIPTION
…tely, alt_skuom require the inventory adjustment to be marked as inventory_quantity_set. This would be the case as well if edited from the UI

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://www.braintec.com/web#view_type=form&model=project.task&id=132054">[t132054] [mt13607] MIDE DEV V15 Migration - Frepple</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->