### PR TITLE
[t145451][FIX] location name for bom and MO export

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -312,9 +312,15 @@ class exporter(object):
                     and i["manufacturing_warehouse"][1]
                     or self.company
                 )
+                self.stock_location = (
+                    i["manufacturing_warehouse"]
+                    and self.env["stock.warehouse"].browse(i["manufacturing_warehouse"][0]).lot_stock_id
+                    or self.company
+                )
             except Exception:
                 self.calendar = None
                 self.mfg_location = None
+                self.stock_location = None
             if self.singlecompany:
                 # Create a new context to limit the data to the selected company
                 self.generator.setContext(allowed_company_ids=[i["id"]])
@@ -964,7 +970,8 @@ class exporter(object):
             #     i['routing_id'] = dummy_mrp_route_m2o_read
 
             # Determine the location
-            location = self.mfg_location
+            location = self.stock_location
+            location_name = location.display_name
 
             product_template = self.product_templates.get(i["product_tmpl_id"][0], None)
             if not product_template:
@@ -996,12 +1003,12 @@ class exporter(object):
                     # routing.
                     operation = "%s @ %s %d" % (
                         product_buf["name"],
-                        subcontractor.get("name", location),
+                        subcontractor.get("name", location_name),
                         i["id"],
                     )
                     if len(operation) > 300:
                         suffix = " @ %s %d" % (
-                            subcontractor.get("name", location),
+                            subcontractor.get("name", location_name),
                             i["id"],
                         )
                         operation = "%s%s" % (
@@ -1027,7 +1034,7 @@ class exporter(object):
                                 subcontractor.get("priority", 1),
                                 subcontractor.get("size_minimum", 0),
                                 quoteattr(product_buf["name"]),
-                                quoteattr(location),
+                                quoteattr(location_name),
                             )
                         else:
                             duration_per = (
@@ -1044,7 +1051,7 @@ class exporter(object):
                                 self.manufacturing_lead,
                                 i["sequence"] or 1,
                                 quoteattr(product_buf["name"]),
-                                quoteattr(location),
+                                quoteattr(location_name),
                             )
 
                         convertedQty = self.convert_qty_uom(


### PR DESCRIPTION
important background info:

because frepple doesn't imply children location in it's routes and needs them to be explicit, we cannot export actual locations of stock, operation types, etc. because frepple could then not reserve / use stock from those child locations like Odoo would
for this reason it was decided whenever locations should be exported, instead use the main stock location of the warehouse that is associated to the location in question.
with that in mind, for bills of material and MO the location exported is wrong. From 15 test we get the warehouse name (Alainé Sennecé-lès-Mâcon) instead of the main stock location (ASM/Stock)

when exporting the bills of materials in V13, we do have the location we want (ASM/Stock)

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=145451">[t145451] [MIFR15] [DEV] Migration v15 - BUG Frepple Export BoM / MO</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->