### PR TITLE
[bt#26736] Fixed browse of product product with a template id. Added exception logging to the failure of uom change of qties.

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -375,17 +375,17 @@ class exporter(object):
         if not product_id:
             return qty * self.uom[uom_id]["factor"]
         else:
-            product = self.env['product.product'].browse(product_id)
+            product = self.env['product.template'].browse(product_id)
             uom = self.env['uom.uom'].browse(uom_id)
 
             # I use the normal Odoo's conversion.
             # If it fails, I return what the original frePPLe code returns.
             try:
                 return uom._compute_quantity(qty, product.uom_id, raise_if_failure=True)
-            except Exception:
+            except Exception as e:
                 logger.warning(
-                    "Can't convert from %s for product %s"
-                    % (self.uom[uom_id]["name"], product_id)
+                    "Can't convert from %s for product %s. With error: %s"
+                    % (self.uom[uom_id]["name"], product_id, str(e))
                 )
                 return qty * self.uom[uom_id]["factor"]
 


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=26736">[bt#26736] Escalation to Customer Care:  False lot number of Manufactured Products in V15 (#8476)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->