### PR TITLE
[t149841][bt#27731] Removed a unnecesary qty conversion in flowplans. Added respect reservations to the frepple tab in the companies view

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1642,19 +1642,9 @@ class exporter(object):
                     )
                     if not item:
                         continue
-                    qty = self.convert_qty_uom(
-                        max(
-                            0,
-                            mv["product_qty"]
-                            - (
-                                mv["reserved_availability"]
-                                if self.respect_reservations
-                                else 0
-                            ),
-                        ),
-                        mv["product_uom"],
-                        self.product_product[mv["product_id"][0]]["template"],
-                    )
+
+                    qty = mv["product_qty"] - ( mv["reserved_availability"] if self.respect_reservations else 0 )
+
                     yield '<flowplan status="confirmed" quantity="%s"><item name=%s/></flowplan>\n' % (
                         -qty,
                         quoteattr(item["name"]),

--- a/frepple/views/res_company.xml
+++ b/frepple/views/res_company.xml
@@ -20,6 +20,7 @@
                         <field name="stock_rules_domain" widget="domain" options="{'model': 'stock.rule'}"/>
                         <field name="tz_for_exporting"/>
                         <field name="frepple_export_language"/>
+                        <field name="respect_reservations"/>
                     </group>
                 </page>
             </xpath>


### PR DESCRIPTION


<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=27731">[bt#27731] MIUS Hypercare:  Incorrect data in Frepple (#8818)</a></li>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=149841">[t149841] [NORAM15] [DEV] NORAM Hypercare</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.xml, .py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->