### PR TITLE
[bt#28702] Fix Type Error when Quoting Non-String Values

### DIFF
--- a/frepple/misc/tree.py
+++ b/frepple/misc/tree.py
@@ -87,7 +87,7 @@ class Node:
             # Prints the start of the entity.
             tag = ['<{}'.format(self.tag)]
             if self.attrs:
-                tag.append(' '.join(['{}={}'.format(k, quoteattr(v)) for k, v in sorted(self.attrs.items())]))
+                tag.append(' '.join(['{}={}'.format(k, quoteattr(str(v))) for k, v in sorted(self.attrs.items())]))
             tag[-1] += '>' if is_inlined else '/>'
             _list.append(' '.join(tag))
 


### PR DESCRIPTION
`quoteattr()` cannot handle e.g. `False` values.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=28702">[bt#28702] Escalation to Customer Care:  Impossible to load data from Odoo in Frepple (#9051)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->