### PR TITLE
[bt#29520][bt#29446] Change Purchase Order Export Location

### DIFF
--- a/frepple/controllers/outbound.py
+++ b/frepple/controllers/outbound.py
@@ -1490,7 +1490,9 @@ class exporter(object):
                 # if PO status is done, we should ignore this receipt
                 if j["state"] == "done":
                     continue
-                location = self.map_locations.get(i["location_dest_id"][0], None)
+                location = self.env['purchase.order'].browse(
+                    j["id"]
+                ).picking_type_id.warehouse_id.lot_stock_id.get_warehouse_stock_location().complete_name
                 if not location:
                     continue
                 start = self.formatDateTime(j["date_order"])


### PR DESCRIPTION
Changes the purchase order export location to use the warehouse as defined by Mind-Noram and Mind-Fr.

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=29520">[bt#29520] Delica NORAM (CC): [ls-1084] [deno-19] Incorrect Location affecting Frepple Forecast (#19) (#1084)</a></li>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=helpdesk.ticket&id=29446">[bt#29446] Delica FR (CC): [ls-1110] [defr-9840] Double forecast for dropship in Frepple (#9840) (#1110)</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>frepple</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->